### PR TITLE
add a Contributing, Code of Conduct and Security documents

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -12,6 +12,7 @@ We are committed to a welcoming, respectful, and inclusive community for everyon
 - Assume good intent and ask clarifying questions before escalating.
 - Give and receive constructive technical feedback.
 - Keep discussion focused on ideas and evidence.
+- Respect maintainer and reviewer time by engaging in good faith and responding thoughtfully to review.
 - Respect differing viewpoints and lived experiences.
 
 ## Unacceptable behavior
@@ -21,6 +22,7 @@ We are committed to a welcoming, respectful, and inclusive community for everyon
 - Sexualized language or unwelcome sexual attention.
 - Doxxing, sharing private information, or threats.
 - Repeated disruption, trolling, or bad-faith engagement.
+- Repeatedly submitting unreviewed, low-quality, or misleadingly presented generated content.
 
 ## Scope
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Code of Conduct
+
+This Code of Conduct applies across repositories in the TuringLang organization unless a repository defines its own policy.
+
+## Our commitment
+
+We are committed to a welcoming, respectful, and inclusive community for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Expected behavior
+
+- Be respectful in language and tone.
+- Assume good intent and ask clarifying questions before escalating.
+- Give and receive constructive technical feedback.
+- Keep discussion focused on ideas and evidence.
+- Respect differing viewpoints and lived experiences.
+
+## Unacceptable behavior
+
+- Harassment, intimidation, discrimination, or hate speech.
+- Personal attacks, insults, or deliberately inflammatory comments.
+- Sexualized language or unwelcome sexual attention.
+- Doxxing, sharing private information, or threats.
+- Repeated disruption, trolling, or bad-faith engagement.
+
+## Scope
+
+This policy applies in project spaces, including issues, pull requests, discussions, review comments, and other community communication channels.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, report it to repository or organization maintainers.
+
+- Prefer private channels where available (for example, direct contact methods listed by maintainers).
+- Include links, timestamps, and relevant context so maintainers can investigate quickly.
+- Do not post sensitive reports publicly.
+
+## Enforcement
+
+Maintainers are responsible for clarifying and enforcing this policy. They may take any action they consider appropriate, including warnings, comment moderation, temporary restrictions, or bans.
+
+All reports will be reviewed promptly and handled with discretion.
+
+## Attribution
+
+This policy is informed by widely used open-source community standards, including the Contributor Covenant.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,6 +22,7 @@ We are committed to a welcoming, respectful, and inclusive community for everyon
 - Sexualized language or unwelcome sexual attention.
 - Doxxing, sharing private information, or threats.
 - Repeated disruption, trolling, or bad-faith engagement.
+- Spam, including repeated assignment requests, repeated review pings, or comments that do not add useful information.
 - Repeatedly submitting unreviewed, low-quality, or misleadingly presented generated content.
 
 ## Scope

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,4 +83,4 @@ When a contribution appears non-compliant with this policy, maintainers may use 
 - Look for issues labeled `help wanted`.
 - If you are unsure about scope or design, open a discussion before implementing a large change.
 
-Thanks for helping make the Turing Language community sustainable, welcoming, and high quality.
+Thanks for helping make the TuringLang community sustainable, welcoming, and high quality.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,17 +11,15 @@ This policy applies organization-wide through the shared `.github` repository. I
 
 Our standard is simple: a contribution should be worth more to the project than the time required to review it.
 
-## AI and tool-use policy
+## AI and tool-use guidance
 
-Contributors may use AI tools, editors, and automation with one non-negotiable rule: **a human must stay in the loop**.
+Contributors may use AI tools, editors, and automation, but every contribution must meet the same review bar as human-written work. The main rule is simple: **a human must stay in the loop**.
 
 ### Required
 
 - You must read, review, and understand all tool-generated code or text before requesting review.
 - You are the author of the contribution and fully accountable for correctness, quality, licensing, and security.
-- You must be transparent about substantial tool usage.
-  - Add an AI disclosure in your pull request description.
-  - Include the model/tool name and a short note on how it was used.
+- Your PR must clearly explain the motivation, implementation decisions, and validation steps in your own words.
 
 ### Not allowed
 
@@ -33,6 +31,8 @@ Contributors may use AI tools, editors, and automation with one non-negotiable r
 
 - Start with small, understandable changes if you are new to a repository.
 - Write PR descriptions yourself (you may use tools for copy-editing or translation).
+- If AI assistance was substantial, mention it briefly in the PR description.
+  - For example, note the model/tool name and whether it was used for drafting, refactoring, tests, or documentation.
 - Prefer incremental PRs over large, hard-to-review submissions.
 
 ## Pull request guidelines
@@ -41,6 +41,7 @@ Contributors may use AI tools, editors, and automation with one non-negotiable r
 - Include tests for behavior changes.
 - Update documentation when public behavior, APIs, or workflows change.
 - Add clear reproduction and validation steps so reviewers can verify quickly.
+- Self-review your PR before requesting maintainer review, especially if any part of it was generated or rewritten by tools.
 
 ### PR description format (for non-trivial changes)
 
@@ -49,8 +50,7 @@ Contributors may use AI tools, editors, and automation with one non-negotiable r
 - **How to test**: Exact steps and expected results.
 - **Before/After**: Required for UI or UX changes (screenshots or video).
 - **Risks/Open questions**: Any known limitations, trade-offs, or follow-ups.
-
-End with an AI disclosure after a separator (`---`) when AI/tool assistance was substantial.
+- **Tool assistance**: Optional; recommended when AI/tool assistance was substantial.
 
 ## Quality bar
 
@@ -69,12 +69,12 @@ Using AI tools does not remove copyright obligations. Do not submit generated co
 
 ## Handling policy violations
 
-Maintainers may request changes, pause review, or close/lock threads when contributions are repeatedly extractive or non-compliant.
+Maintainers may request changes, pause review, or close/lock threads when contributions are repeatedly extractive, low-quality, or non-compliant. PRs that do not meet the review bar may be closed even if they were submitted in good faith.
 
 When a contribution appears non-compliant with this policy, maintainers may use the template below:
 
 > This contribution does not appear to meet our policy for tool-assisted submissions.
-> Please revise it to make the change easier to review and add the required disclosure.
+> Please revise it to make the change easier to review.
 > In particular, ensure the PR clearly explains motivation, implementation decisions,
 > and how you validated correctness.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,6 @@ When a contribution appears non-compliant with this policy, maintainers may use 
 
 ## Need help?
 
-- Look for issues labeled `help wanted`.
-- If you are unsure about scope or design, open a discussion before implementing a large change.
+If you are unsure about scope or design, please open a issue or a discussion on Slack / Discourse before implementing a large change.
 
 Thanks for helping make the TuringLang community sustainable, welcoming, and high quality.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This policy applies organization-wide through the shared `.github` repository. I
 
 ## Overall expectations
 
-- Write clear, professional, native-sounding English in issues, pull requests, and review comments.
+- Write clear and professional English in issues, pull requests, and review comments.
 - Explain reasoning, not only the code delta. For bug fixes, describe the root cause and why your fix addresses it.
 - Keep contributions focused and appropriately scoped for review.
 - Be ready to answer technical questions about your changes during review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,8 @@ This policy applies organization-wide through the shared `.github` repository. I
 - Write clear and professional English in issues, pull requests, and review comments.
 - Explain reasoning, not only the code delta. For bug fixes, describe the root cause and why your fix addresses it.
 - Keep contributions focused and appropriately scoped for review.
+- Do not post comments that only ask whether you may work on an issue. Instead, describe the proposal, explain how you plan to implement it, and open a PR when ready.
+- Do not spam maintainers with repeated comments, mentions, or low-effort requests for assignment or review.
 - Be ready to answer technical questions about your changes during review.
 
 Our standard is simple: a contribution should be worth more to the project than the time required to review it.
@@ -80,6 +82,6 @@ When a contribution appears non-compliant with this policy, maintainers may use 
 
 ## Need help?
 
-If you are unsure about scope or design, please open a issue or a discussion on Slack / Discourse before implementing a large change.
+If you are unsure about scope or design, please open an issue or a discussion on Slack / Discourse before implementing a large change. Include the concrete change you want to make and how you plan to approach it.
 
 Thanks for helping make the TuringLang community sustainable, welcoming, and high quality.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to Turing.jl Organization Repositories
+
+This policy applies organization-wide through the shared `.github` repository. Individual repositories may add project-specific requirements, but this document defines the default expectations.
+
+## Overall expectations
+
+- Write clear, professional, native-sounding English in issues, pull requests, and review comments.
+- Explain reasoning, not only the code delta. For bug fixes, describe the root cause and why your fix addresses it.
+- Keep contributions focused and appropriately scoped for review.
+- Be ready to answer technical questions about your changes during review.
+
+Our standard is simple: a contribution should be worth more to the project than the time required to review it.
+
+## AI and tool-use policy
+
+Contributors may use AI tools, editors, and automation with one non-negotiable rule: **a human must stay in the loop**.
+
+### Required
+
+- You must read, review, and understand all tool-generated code or text before requesting review.
+- You are the author of the contribution and fully accountable for correctness, quality, licensing, and security.
+- You must be transparent about substantial tool usage.
+  - Add an AI disclosure in your pull request description.
+  - Include the model/tool name and a short note on how it was used.
+
+### Not allowed
+
+- Submitting unreviewed AI output for maintainers to debug or redesign.
+- Using AI tools to resolve issues labeled `good first issue`.
+  - These are learning-oriented tasks intended for hands-on contributor growth.
+
+### Recommended
+
+- Start with small, understandable changes if you are new to a repository.
+- Write PR descriptions yourself (you may use tools for copy-editing or translation).
+- Prefer incremental PRs over large, hard-to-review submissions.
+
+## Pull request guidelines
+
+- Keep PRs small enough for effective review. If a PR becomes very large, split it.
+- Include tests for behavior changes.
+- Update documentation when public behavior, APIs, or workflows change.
+- Add clear reproduction and validation steps so reviewers can verify quickly.
+
+### PR description format (for non-trivial changes)
+
+- **What**: Concrete summary of behavior changes.
+- **Why**: Problem statement, motivation, and why this approach was chosen.
+- **How to test**: Exact steps and expected results.
+- **Before/After**: Required for UI or UX changes (screenshots or video).
+- **Risks/Open questions**: Any known limitations, trade-offs, or follow-ups.
+
+End with an AI disclosure after a separator (`---`) when AI/tool assistance was substantial.
+
+## Quality bar
+
+Before opening a PR, ensure:
+
+- You can explain the change end-to-end.
+- Tests pass locally (or in CI where appropriate).
+- The patch is intentionally scoped and not padded with unrelated edits.
+- Commit messages and PR descriptions are clear and useful to reviewers.
+
+## Copyright and licensing
+
+By contributing, you confirm that you have the right to submit the content under the repository license.
+
+Using AI tools does not remove copyright obligations. Do not submit generated content that reproduces copyrighted or otherwise restricted material without proper rights.
+
+## Handling policy violations
+
+Maintainers may request changes, pause review, or close/lock threads when contributions are repeatedly extractive or non-compliant.
+
+When a contribution appears non-compliant with this policy, maintainers may use the template below:
+
+> This contribution does not appear to meet our policy for tool-assisted submissions.
+> Please revise it to make the change easier to review and add the required disclosure.
+> In particular, ensure the PR clearly explains motivation, implementation decisions,
+> and how you validated correctness.
+
+## Need help?
+
+- Look for issues labeled `help wanted`.
+- If you are unsure about scope or design, open a discussion before implementing a large change.
+
+Thanks for helping make the Turing Language community sustainable, welcoming, and high quality.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Organization-wide GitHub Actions and other metadata.
 
+Default community health files:
+
+- `CONTRIBUTING.md`
+- `CODE_OF_CONDUCT.md`
+- `SECURITY.md`
+
 See the GitHub documentation about [creating default community health files](https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file) and
 [sharing workflows](https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/sharing-workflows-with-your-organization)
 for details on how this repository works.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+This security policy applies across repositories in the TuringLang organization unless a repository defines its own policy.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately.
+
+- Use GitHub private vulnerability reporting in the affected repository when available.
+- If private reporting is not available, contact repository maintainers directly.
+- Do not open public issues for unpatched vulnerabilities.
+
+When possible, include:
+
+- Affected repository, branch, and version
+- Reproduction steps or proof of concept
+- Expected impact and attack preconditions
+- Any mitigation ideas you have already tested
+
+## What to expect
+
+After receiving a report, maintainers will:
+
+- Acknowledge receipt as soon as practical
+- Assess severity and scope
+- Work on a fix and coordinated disclosure
+- Credit the reporter when appropriate (if requested)
+
+Response and remediation timelines depend on severity, complexity, and maintainer availability.
+
+## Disclosure guidance
+
+Please allow maintainers reasonable time to investigate and release a fix before public disclosure.
+
+If you are unsure whether something is security-sensitive, report it privately first.
+
+## Supported versions
+
+Support windows vary by repository. Unless stated otherwise in a repository's own policy, only actively maintained branches and current releases should be assumed to receive security fixes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,8 @@ When possible, include:
 - Expected impact and attack preconditions
 - Any mitigation ideas you have already tested
 
+Reports may use AI or other tools for drafting or analysis, but please verify the issue yourself before reporting. Do not submit speculative or unreviewed tool-generated vulnerability reports.
+
 ## What to expect
 
 After receiving a report, maintainers will:


### PR DESCRIPTION
Yes, it's possible to have a organization wide guides, I can't find any official github docs source mentioning this, I am sure I read this somewhere few months back. I am unable to find that right now. But I found the example:

P4 Language (I haven't heard of before) have CONTRIBUTING.md in .github repo and it appears in all the repos which does have there own CONTRIBUTING.md, see: https://github.com/p4lang/p4mlir-incubator?tab=contributing-ov-file

Same applies to Code of Conduct and Security documents